### PR TITLE
Replace the temporal INSDC URIs to DDBJ's for release

### DIFF
--- a/insdc.ttl
+++ b/insdc.ttl
@@ -1,4593 +1,4594 @@
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@base <http://ddbj.nig.ac.jp/ontologies/sequence/> .
 @prefix : <> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://insdc.org/owl/>
+:
     a owl:Ontology ;
     rdfs:label "insdc" ;
     rdfs:seeAlso <http://www.insdc.org/> .
 
-<http://insdc.org/owl/ASAP>
+:ASAP
     a owl:Class ;
     rdfs:label "ASAP" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/ATCC>
+:ATCC
     a owl:Class ;
     rdfs:label "ATCC" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Assembly_Gap>
+:Assembly_Gap
     a owl:Class ;
     rdfs:comment "gap between two components of a CON record that is part of a genome assembly;" ;
     rdfs:label "assembly_gap" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gap_type>
+        owl:onProperty :gap_type
     ], [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/linkage_evidence>
+        owl:onProperty :linkage_evidence
     ], [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/estimated_length>
+        owl:onProperty :estimated_length
     ] .
 
-<http://insdc.org/owl/Attenuator>
+:Attenuator
     a owl:Class ;
     rdfs:comment """1) region of DNA at which regulation of termination of transcription occurs, which controls the expression of some bacterial operons;
 2) sequence segment located between the promoter and the first structural gene that causes partial termination of transcription""" ;
     rdfs:label "attenuator" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :gene_synonym
     ] .
 
-<http://insdc.org/owl/BioProject>
+:BioProject
     a owl:Class ;
     rdfs:label "BioProject" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/BioSample>
+:BioSample
     a owl:Class ;
     rdfs:label "BioSample" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/CAAT_Signal>
+:CAAT_Signal
     a owl:Class ;
     rdfs:comment "CAAT box; part of a conserved sequence located about 75 bp up-stream of the start point of eukaryotic transcription units which may be involved in RNA polymerase binding; consensus=GG(C or T)CAATCT [1,2]." ;
     rdfs:label "CAAT_signal" ;
     rdfs:seeAlso <http://identifiers.org/pubmed/6193753>, <http://identifiers.org/pubmed/6985477> ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/CDD>
+:CDD
     a owl:Class ;
     rdfs:label "CDD" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/CON>
+:CON
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/Division> .
+    rdfs:subClassOf :Division .
 
-<http://insdc.org/owl/Centromere>
+:Centromere
     a owl:Class ;
     rdfs:comment "region of biological interest identified as a centromere and which has been experimentally characterized;" ;
     rdfs:label "centromere" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Coding_Sequence>
+:Coding_Sequence
     a owl:Class ;
     rdfs:comment "coding sequence; sequence of nucleotides that corresponds with the sequence of amino acids in a protein (location includes stop codon); feature includes amino acid conceptual translation." ;
     rdfs:label "CDS" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/artificial_location>
+        owl:onProperty :artificial_location
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/codon_start>
+        owl:onProperty :codon_start
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/EC_number>
+        owl:onProperty :EC_number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/exception>
+        owl:onProperty :exception
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/protein_id>
+        owl:onProperty :protein_id
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/ribosomal_slippage>
+        owl:onProperty :ribosomal_slippage
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/translation>
+        owl:onProperty :translation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/transl_except>
+        owl:onProperty :transl_except
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/transl_table>
+        owl:onProperty :transl_table
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Comment>
+:Comment
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Constant_Region>
+:Constant_Region
     a owl:Class ;
     rdfs:comment "constant region of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains; includes one or more exons depending on the particular chain" ;
     rdfs:label "C_region" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/ContigEntry>
+:ContigEntry
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/Entry> .
+    rdfs:subClassOf :Entry .
 
-<http://insdc.org/owl/DDBJ>
+:DDBJ
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/INSDC> .
+    rdfs:subClassOf :INSDC .
 
-<http://insdc.org/owl/DNA>
-    a <http://insdc.org/owl/Molecule>, <http://insdc.org/owl/MoleculeScope>, owl:NamedIndividual .
+:DNA
+    a :Molecule, :MoleculeScope, owl:NamedIndividual .
 
-<http://insdc.org/owl/Database>
+:Database
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Displacement_Loop>
+:Displacement_Loop
     a owl:Class ;
     rdfs:comment "displacement loop; a region within mitochondrial DNA in which a short stretch of RNA is paired with one strand of DNA, displacing the original partner DNA strand in this region; also used to describe the displacement of a region of one strand of duplex DNA by a single stranded invader in the reaction catalyzed by RecA protein" ;
     rdfs:label "D-loop" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/Diversity_Segment>
+:Diversity_Segment
     a owl:Class ;
     rdfs:comment "Diversity segment of immunoglobulin heavy chain, and T-cell receptor beta chain;" ;
     rdfs:label "D_segment" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :product
     ] .
 
-<http://insdc.org/owl/Division>
+:Division
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/ECOCYC>
+:ECOCYC
     a owl:Class ;
     rdfs:label "ECOCYC" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/EC_number>
+:EC_number
     a owl:DatatypeProperty ;
     rdfs:comment "Enzyme Commission number for enzyme product of sequence" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Mature_Peptide>
+        owl:unionOf (:Coding_Sequence
+            :Exon
+            :Mature_Peptide
         )
     ] ;
     rdfs:label "EC_number" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/ENA>
+:ENA
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/INSDC> .
+    rdfs:subClassOf :INSDC .
 
-<http://insdc.org/owl/ERIC>
+:ERIC
     a owl:Class ;
     rdfs:label "ERIC" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/EcoGene>
+:EcoGene
     a owl:Class ;
     rdfs:label "EcoGene" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Enhancer>
+:Enhancer
     a owl:Class ;
     rdfs:comment "a cis-acting sequence that increases the utilization of (some)  eukaryotic promoters, and can function in either orientation and in any location (upstream or downstream) relative to the promoter;" ;
     rdfs:label "enhancer" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Entry>
+:Entry
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Exon>
+:Exon
     a owl:Class ;
     rdfs:comment "region of genome that codes for portion of spliced mRNA, rRNA and tRNA; may contain 5'UTR, all CDSs and 3' UTR;" ;
     rdfs:label "exon" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/EC_number>
+        owl:onProperty :EC_number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Feature>
+:Feature
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Five_Prime_UTR>
+:Five_Prime_UTR
     a owl:Class ;
     rdfs:comment "region at the 5' end of a mature transcript (preceding the initiation codon) that is not translated into a protein;" ;
     rdfs:label "5'UTR" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/GC_Signal>
+:GC_Signal
     a owl:Class ;
     rdfs:comment "GC box; a conserved GC-rich region located upstream of the start point of eukaryotic transcription units which may occur in multiple copies or in either orientation; consensus=GGGCGG;" ;
     rdfs:label "GC_signal" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/GI>
+:GI
     a owl:Class ;
     rdfs:label "GI" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/GO>
+:GO
     a owl:Class ;
     rdfs:label "GO" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/GOA>
+:GOA
     a owl:Class ;
     rdfs:label "GOA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Gap>
+:Gap
     a owl:Class ;
     rdfs:comment "gap in the sequence" ;
     rdfs:label "gap" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/estimated_length>
+        owl:onProperty :estimated_length
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
-<http://insdc.org/owl/Genbank>
+:Genbank
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/INSDC> .
+    rdfs:subClassOf :INSDC .
 
-<http://insdc.org/owl/Gene>
+:Gene
     a owl:Class ;
     rdfs:comment "region of biological interest identified as a gene and for which a name has been assigned;" ;
     rdfs:label "gene" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/GeneID>
+:GeneID
     a owl:Class ;
     rdfs:label "GeneID" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Greengenes>
+:Greengenes
     a owl:Class ;
     rdfs:label "Greengenes" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/HMP>
+:HMP
     a owl:Class ;
     rdfs:label "HMP" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/HOMD>
+:HOMD
     a owl:Class ;
     rdfs:label "HOMD" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/HSSP>
+:HSSP
     a owl:Class ;
     rdfs:label "HSSP" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/INSDC>
+:INSDC
     a owl:Class ;
     rdfs:comment "International Nucleotide Sequence Database Collaboration" ;
     rdfs:label "INSDC" ;
     rdfs:seeAlso <http://www.insdc.org/about> ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/ISFinder>
+:ISFinder
     a owl:Class ;
     rdfs:label "ISFinder" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/InterPro>
+:InterPro
     a owl:Class ;
     rdfs:label "InterPro" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Intervening_DNA>
+:Intervening_DNA
     a owl:Class ;
     rdfs:comment "intervening DNA; DNA which is eliminated through any of several kinds of recombination;" ;
     rdfs:label "iDNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Intron>
+:Intron
     a owl:Class ;
     rdfs:comment "a segment of DNA that is transcribed, but removed from within the transcript by splicing together the sequences (exons) on either side of it;" ;
     rdfs:label "intron" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Joining_Segment>
+:Joining_Segment
     a owl:Class ;
     rdfs:comment "joining segment of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains;" ;
     rdfs:label "J_segment" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Keyword>
+:Keyword
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Location>
+:Location
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Long_Terminal_Repeat>
+:Long_Terminal_Repeat
     a owl:Class ;
     rdfs:comment "long terminal repeat, a sequence directly repeated at both ends of a defined sequence, of the sort typically found in retroviruses;" ;
     rdfs:label "LTR" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/MandatoryQualifiers>
+:MandatoryQualifiers
     a owl:Class ;
     rdfs:comment "qualifiers required with the key; if there are no mandatory qualifiers, this field is omitted." ;
     rdfs:label "Mandatory qualifiers" ;
-    rdfs:subClassOf <http://insdc.org/owl/Qualifier> ;
-    owl:disjointWith <http://insdc.org/owl/OptionalQualifier> .
+    rdfs:subClassOf :Qualifier ;
+    owl:disjointWith :OptionalQualifier .
 
-<http://insdc.org/owl/Mature_Peptide>
+:Mature_Peptide
     a owl:Class ;
     rdfs:comment "mature peptide or protein coding sequence; coding sequence for the mature or final peptide or protein product following post-translational modification; the location does not include the stop codon (unlike the corresponding CDS);" ;
     rdfs:label "mat_peptide" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/EC_number>
+        owl:onProperty :EC_number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Messenger_RNA>
+:Messenger_RNA
     a owl:Class ;
     rdfs:comment "messenger RNA; includes 5'untranslated region (5'UTR), coding sequences (CDS, exon) and 3'untranslated region (3'UTR);" ;
     rdfs:label "mRNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/artificial_location>
+        owl:onProperty :artificial_location
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Minus_10_Signal>
+:Minus_10_Signal
     a owl:Class ;
     rdfs:comment "Pribnow box; a conserved region about 10 bp upstream of the start point of bacterial transcription units which may be involved in binding RNA polymerase; consensus=TAtAaT [1,2,3,4];" ;
     rdfs:label "-10_signal" ;
     rdfs:seeAlso <http://identifiers.org/pubmed/1054851>, <http://identifiers.org/pubmed/1093168>, <http://identifiers.org/pubmed/6344016>, <http://identifiers.org/pubmed/94251> ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Minus_35_Signal>
+:Minus_35_Signal
     a owl:Class ;
     rdfs:comment "a conserved hexamer about 35 bp upstream of the start point of bacterial transcription units; consensus=TTGACa or TGTTGACA;" ;
     rdfs:label "-35_signal" ;
     rdfs:seeAlso <http://identifiers.org/pubmed/1095210>, <http://identifiers.org/pubmed/1256568>, <http://identifiers.org/pubmed/6181373> ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Miscellaneous_Binding_Site>
+:Miscellaneous_Binding_Site
     a owl:Class ;
     rdfs:comment "site in nucleic acid which covalently or non-covalently binds another moiety that cannot be described by any other binding key (primer_bind or protein_bind);" ;
     rdfs:label "misc_binding" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/Miscellaneous_Difference>
+:Miscellaneous_Difference
     a owl:Class ;
     rdfs:comment "feature sequence is different from that presented in the entry and cannot be described by any other difference key (unsure, old_sequence, variation, or modified_base);" ;
     rdfs:label "misc_difference" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/clone>
+        owl:onProperty :clone
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Miscellaneous_Feature>
+:Miscellaneous_Feature
     a owl:Class ;
     rdfs:comment "region of biological interest which cannot be described by any other feature key; a new or rare feature;" ;
     rdfs:label "misc_feature" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Miscellaneous_RNA>
+:Miscellaneous_RNA
     a owl:Class ;
     rdfs:comment "any transcript or RNA product that cannot be defined by other RNA keys (prim_transcript, precursor_RNA, mRNA, 5'UTR, 3'UTR, exon, CDS, sig_peptide, transit_peptide, mat_peptide, intron, polyA_site, ncRNA, rRNA and tRNA);" ;
     rdfs:label "misc_RNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Miscellaneous_Recombination_Site>
+:Miscellaneous_Recombination_Site
     a owl:Class ;
     rdfs:comment "site of any generalized, site-specific or replicative recombination event where there is a breakage and reunion of duplex DNA that cannot be described by other recombination keys or qualifiers of source key (/proviral);" ;
     rdfs:label "misc_recomb" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Miscellaneous_Signal>
+:Miscellaneous_Signal
     a owl:Class ;
     rdfs:comment "any region containing a signal controlling or altering gene function or expression that cannot be described by other signal keys (promoter, CAAT_signal, TATA_signal, -35_signal, -10_signal, GC_signal, RBS, polyA_signal, enhancer, attenuator, terminator, and rep_origin)." ;
     rdfs:label "misc_signal" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Miscellaneous_Structure>
+:Miscellaneous_Structure
     a owl:Class ;
     rdfs:comment "any secondary or tertiary nucleotide structure or conformation that cannot be described by other Structure keys (stem_loop and D-loop);" ;
     rdfs:label "misc_structure" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Mobile_Element>
+:Mobile_Element
     a owl:Class ;
     rdfs:comment "region of genome containing mobile elements;" ;
     rdfs:label "mobile_element" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mobile_element_type>
+        owl:onProperty :mobile_element_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_family>
+        owl:onProperty :rpt_family
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :rpt_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Modified_Base>
+:Modified_Base
     a owl:Class ;
     rdfs:comment "the indicated nucleotide is a modified nucleotide and should be substituted for by the indicated molecule (given in the mod_base qualifier value)" ;
     rdfs:label "modified_base" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mod_base>
+        owl:onProperty :mod_base
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/frequency>
+        owl:onProperty :frequency
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/Molecule>
+:Molecule
     a owl:Class .
 
-<http://insdc.org/owl/MoleculeScope>
+:MoleculeScope
     a owl:Class ;
     rdfs:label "Molecule scope" .
 
-<http://insdc.org/owl/NA>
-    a <http://insdc.org/owl/Molecule>, owl:NamedIndividual .
+:NA
+    a :Molecule, owl:NamedIndividual .
 
-<http://insdc.org/owl/NBRC>
+:NBRC
     a owl:Class ;
     rdfs:label "NBRC" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/N_Region>
+:N_Region
     a owl:Class ;
     rdfs:comment "extra nucleotides inserted between rearranged immunoglobulin segments." ;
     rdfs:label "N_region" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Non_Coding_RNA>
+:Non_Coding_RNA
     a owl:Class ;
     rdfs:comment "a non-protein-coding gene, other than ribosomal RNA and transfer RNA, the functional molecule of which is the RNA transcript;" ;
     rdfs:label "ncRNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/ncRNA_class>
+        owl:onProperty :ncRNA_class
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Old_Sequence>
+:Old_Sequence
     a owl:Class ;
     rdfs:comment "the presented sequence revises a previous version of the sequence at this location;" ;
     rdfs:label "old_sequence" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ] .
 
-<http://insdc.org/owl/Operon>
+:Operon
     a owl:Class ;
     rdfs:comment "region containing polycistronic transcript including a cluster of genes that are under the control of the same regulatory sequences/promotor and in the same biological pathway" ;
     rdfs:label "operon" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/OptionalQualifier>
+:OptionalQualifier
     a owl:Class ;
     rdfs:comment "optional qualifiers associated with the key" ;
     rdfs:label "Optional qualifiers" ;
-    rdfs:subClassOf <http://insdc.org/owl/Qualifier> .
+    rdfs:subClassOf :Qualifier .
 
-<http://insdc.org/owl/OrganismScope>
+:OrganismScope
     a owl:Class ;
     rdfs:label "Organism scope" .
 
-<http://insdc.org/owl/Origin_Of_Transfer>
+:Origin_Of_Transfer
     a owl:Class ;
     rdfs:comment "origin of transfer; region of a DNA molecule where transfer is initiated during the process of conjugation or mobilization" ;
     rdfs:label "oriT" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/direction>
+        owl:onProperty :direction
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_family>
+        owl:onProperty :rpt_family
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :rpt_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_range>
+        owl:onProperty :rpt_unit_range
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_seq>
+        owl:onProperty :rpt_unit_seq
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/PCR_conditions>
+:PCR_conditions
     a owl:DatatypeProperty ;
     rdfs:comment "description of reaction conditions and components for PCR" ;
-    rdfs:domain <http://insdc.org/owl/Primer_Binding_Site> ;
+    rdfs:domain :Primer_Binding_Site ;
     rdfs:label "PCR_conditions" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/PCR_primers>
+:PCR_primers
     a owl:DatatypeProperty ;
     rdfs:comment "PCR primers that were used to amplify the sequence. A single /PCR_primers qualifier should contain all the primers used for a single PCR reaction. If multiple forward or reverse primers are present in a  single PCR reaction, multiple sets of fwd_name/fwd_seq or rev_name/rev_seq values will be  present." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "PCR_primers" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/PDB>
+:PDB
     a owl:Class ;
     rdfs:label "PDB" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/PFAM>
+:PFAM
     a owl:Class ;
     rdfs:label "PFAM" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/PSEUDO>
+:PSEUDO
     a owl:Class ;
     rdfs:label "PSEUDO" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Pathema>
+:Pathema
     a owl:Class ;
     rdfs:label "Pathema" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/PolyA_Signal>
+:PolyA_Signal
     a owl:Class ;
     rdfs:comment "recognition region necessary for endonuclease cleavage of an RNA transcript that is followed by polyadenylation; consensus=AATAAA [1];" ;
     rdfs:label "polyA_signal" ;
     rdfs:seeAlso <http://identifiers.org/pubmed/4862513> ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/PolyA_Site>
+:PolyA_Site
     a owl:Class ;
     rdfs:comment "site on an RNA transcript to which will be added adenine residues by post-transcriptional polyadenylation;" ;
     rdfs:label "polyA_site" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/Precursor_RNA>
+:Precursor_RNA
     a owl:Class ;
     rdfs:comment "any RNA species that is not yet the mature RNA product; may include 5' untranslated region (5'UTR), coding sequences (CDS, exon), intervening sequences (intron) and 3' untranslated region (3'UTR);" ;
     rdfs:label "precursor_RNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Primary_Transcript>
+:Primary_Transcript
     a owl:Class ;
     rdfs:comment "primary (initial, unprocessed) transcript; includes 5' untranslated region (5'UTR), coding sequences (CDS, exon), intervening sequences (intron) and 3' untranslated region (3'UTR);" ;
     rdfs:label "prim_transcript" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Primer_Binding_Site>
+:Primer_Binding_Site
     a owl:Class ;
     rdfs:comment "non-covalent primer binding site for initiation of replication, transcription, or reverse transcription; includes site(s) for synthetic e.g., PCR primer elements;" ;
     rdfs:label "primer_bind" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/PCR_conditions>
+        owl:onProperty :PCR_conditions
     ] .
 
-<http://insdc.org/owl/Promoter>
+:Promoter
     a owl:Class ;
     rdfs:comment "region on a DNA molecule involved in RNA polymerase binding to initiate transcription;" ;
     rdfs:label "promoter" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Protein>
+:Protein
     a owl:Class ;
     rdfs:label "Protein" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Protein_Binding_Site>
+:Protein_Binding_Site
     a owl:Class ;
     rdfs:comment "non-covalent protein binding site on nucleic acid;" ;
     rdfs:label "protein_bind" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/PseudoCap>
+:PseudoCap
     a owl:Class ;
     rdfs:label "PseudoCap" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/PubMed>
+:PubMed
     a owl:Class ;
     rdfs:label "PubMed" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Qualifier>
+:Qualifier
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/REBASE>
+:REBASE
     a owl:Class ;
     rdfs:label "REBASE" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/RNA>
-    a <http://insdc.org/owl/Molecule>, owl:NamedIndividual .
+:RNA
+    a :Molecule, owl:NamedIndividual .
 
-<http://insdc.org/owl/Reference>
+:Reference
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Refseq>
+:Refseq
     a owl:Class ;
     rdfs:label "RefSeq" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Repeat_Region>
+:Repeat_Region
     a owl:Class ;
     rdfs:comment "region of genome containing repeating units;" ;
     rdfs:label "repeat_region" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_family>
+        owl:onProperty :rpt_family
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :rpt_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_range>
+        owl:onProperty :rpt_unit_range
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_seq>
+        owl:onProperty :rpt_unit_seq
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/satellite>
+        owl:onProperty :satellite
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Replication_Origin>
+:Replication_Origin
     a owl:Class ;
     rdfs:comment "origin of replication; starting site for duplication of nucleic acid to give two identical copies;" ;
     rdfs:label "rep_origin" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> .
+    rdfs:subClassOf :Feature .
 
-<http://insdc.org/owl/Ribosomal_RNA>
+:Ribosomal_RNA
     a owl:Class ;
     rdfs:comment "mature ribosomal RNA; RNA component of the ribonucleoprotein particle (ribosome) which assembles amino acids into proteins." ;
     rdfs:label "rRNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Ribosome_Binding_Site>
+:Ribosome_Binding_Site
     a owl:Class ;
     rdfs:comment "ribosome binding site;" ;
     rdfs:label "RBS" ;
     rdfs:seeAlso <http://identifiers.org/pubmed/4598299>, <http://identifiers.org/pubmed/6170248> ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Sequence>
+:Sequence
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Sequence_Tagged_Site>
+:Sequence_Tagged_Site
     a owl:Class ;
     rdfs:comment "sequence tagged site; short, single-copy DNA sequence that characterizes a mapping landmark on the genome and can be detected by PCR; a region of the genome can be mapped by determining the order of a series of STSs;" ;
     rdfs:label "STS" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Signal_Peptide>
+:Signal_Peptide
     a owl:Class ;
     rdfs:comment "signal peptide coding sequence; coding sequence for an N-terminal domain of a secreted protein; this domain is involved in attaching nascent polypeptide to the membrane leader sequence;" ;
     rdfs:label "sig_peptide" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Source>
+:Source
     a owl:Class ;
     rdfs:comment "identifies the biological source of the specified span of the sequence; this key is mandatory; more than one source key per sequence is allowed; every entry/record will have, as a minimum, either a single source key spanning the entire sequence or multiple source keys, which together, span the entire sequence." ;
     rdfs:label "source" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/organism>
+        owl:onProperty :organism
     ], [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mol_type>
+        owl:onProperty :mol_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/altitude>
+        owl:onProperty :altitude
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bio_material>
+        owl:onProperty :bio_material
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/cell_line>
+        owl:onProperty :cell_line
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/cell_type>
+        owl:onProperty :cell_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/chromosome>
+        owl:onProperty :chromosome
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/clone>
+        owl:onProperty :clone
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/clone_lib>
+        owl:onProperty :clone_lib
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/collected_by>
+        owl:onProperty :collected_by
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/collection_date>
+        owl:onProperty :collection_date
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/country>
+        owl:onProperty :country
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/cultivar>
+        owl:onProperty :cultivar
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/culture_collection>
+        owl:onProperty :culture_collection
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/dev_stage>
+        owl:onProperty :dev_stage
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/ecotype>
+        owl:onProperty :ecotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/environmental_sample>
+        owl:onProperty :environmental_sample
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/focus>
+        owl:onProperty :focus
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/germline>
+        owl:onProperty :germline
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/haplogroup>
+        owl:onProperty :haplogroup
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/haplotype>
+        owl:onProperty :haplotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/host>
+        owl:onProperty :host
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/identified_by>
+        owl:onProperty :identified_by
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/isolate>
+        owl:onProperty :isolate
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/isolation_source>
+        owl:onProperty :isolation_source
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/lab_host>
+        owl:onProperty :lab_host
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/lat_lon>
+        owl:onProperty :lat_lon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/macronuclear>
+        owl:onProperty :macronuclear
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mating_type>
+        owl:onProperty :mating_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/organelle>
+        owl:onProperty :organelle
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/PCR_primers>
+        owl:onProperty :PCR_primers
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/plasmid>
+        owl:onProperty :plasmid
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pop_variant>
+        owl:onProperty :pop_variant
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/proviral>
+        owl:onProperty :proviral
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rearranged>
+        owl:onProperty :rearranged
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/segment>
+        owl:onProperty :segment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/serotype>
+        owl:onProperty :serotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/serovar>
+        owl:onProperty :serovar
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sex>
+        owl:onProperty :sex
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/specimen_voucher>
+        owl:onProperty :specimen_voucher
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/strain>
+        owl:onProperty :strain
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sub_clone>
+        owl:onProperty :sub_clone
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sub_species>
+        owl:onProperty :sub_species
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sub_strain>
+        owl:onProperty :sub_strain
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/tissue_lib>
+        owl:onProperty :tissue_lib
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/tissue_type>
+        owl:onProperty :tissue_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/transgenic>
+        owl:onProperty :transgenic
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/type_material>
+        owl:onProperty :type_material
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/variety>
+        owl:onProperty :variety
     ] .
 
-<http://insdc.org/owl/Stem_Loop>
+:Stem_Loop
     a owl:Class ;
     rdfs:comment "hairpin; a double-helical region formed by base-pairing between adjacent (inverted) complementary sequences in a single strand of RNA or DNA." ;
     rdfs:label "stem_loop" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Strand>
+:Strand
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/StructuredComment>
+:StructuredComment
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/Comment> .
+    rdfs:subClassOf :Comment .
 
-<http://insdc.org/owl/Submission>
+:Submission
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/Swiss-Prot>
+:Swiss-Prot
     a owl:Class ;
     rdfs:label "UniProtKB/Swiss-Prot" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Switch_Region>
+:Switch_Region
     a owl:Class ;
     rdfs:comment "switch region of immunoglobulin heavy chains; involved in the rearrangement of heavy chain DNA leading to the expression of a different immunoglobulin class from the same B-cell;" ;
     rdfs:label "S_region" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/TATA_Signal>
+:TATA_Signal
     a owl:Class ;
     rdfs:comment "TATA box; Goldberg-Hogness box; a conserved AT-rich septamer found about 25 bp before the start point of each eukaryotic RNA polymerase II transcript unit which may be involved in positioning the enzyme  for correct initiation; consensus=TATA(A or T)A(A or T) [1,2];" ;
     rdfs:label "TATA_signal" ;
     rdfs:seeAlso <http://identifiers.org/pubmed/6251548>, <http://identifiers.org/pubmed/6985477> ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
-<http://insdc.org/owl/TIGRFAM>
+:TIGRFAM
     a owl:Class ;
     rdfs:label "TIGRFAM" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/TPA>
+:TPA
     a owl:Class ;
-    rdfs:subClassOf <http://insdc.org/owl/Division> .
+    rdfs:subClassOf :Division .
 
-<http://insdc.org/owl/Taxon>
+:Taxon
     a owl:Class ;
     rdfs:label "taxon" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Telomere>
+:Telomere
     a owl:Class ;
     rdfs:comment "region of biological interest identified as a telomere and which has been experimentally characterized;" ;
     rdfs:label "telomere" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :rpt_type
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_range>
+        owl:onProperty :rpt_unit_range
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_seq>
+        owl:onProperty :rpt_unit_seq
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Terminator>
+:Terminator
     a owl:Class ;
     rdfs:comment "sequence of DNA located either at the end of the transcript that causes RNA polymerase to terminate transcription;" ;
     rdfs:label "terminator" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Three_Prime_UTR>
+:Three_Prime_UTR
     a owl:Class ;
     rdfs:comment "region at the 3' end of a mature transcript (following the stop codon) that is not translated into a protein;" ;
     rdfs:label "3'UTR" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Topology>
+:Topology
     a owl:Class ;
     rdfs:subClassOf owl:Thing .
 
-<http://insdc.org/owl/TrEMBL>
+:TrEMBL
     a owl:Class ;
     rdfs:label "UniProtKB/TrEMBL" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Transfer_Messenger_RNA>
+:Transfer_Messenger_RNA
     a owl:Class ;
     rdfs:comment "transfer messenger RNA; tmRNA acts as a tRNA first, and then as an mRNA that encodes a peptide tag; the ribosome translates this mRNA region of tmRNA and attaches the encoded peptide tag to the C-terminus of the unfinished protein; this attached tag targets the protein for destruction or proteolysis;" ;
     rdfs:label "tmRNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/tag_peptide>
+        owl:onProperty :tag_peptide
     ] .
 
-<http://insdc.org/owl/Transfer_RNA>
+:Transfer_RNA
     a owl:Class ;
     rdfs:comment "mature transfer RNA, a small RNA molecule (75-85 bases long) that mediates the translation of a nucleic acid sequence into an amino acid sequence;" ;
     rdfs:label "tRNA" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/anticodon>
+        owl:onProperty :anticodon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
-<http://insdc.org/owl/Transit_Peptide>
+:Transit_Peptide
     a owl:Class ;
     rdfs:comment "transit peptide coding sequence; coding sequence for an N-terminal domain of a nuclear-encoded organellar protein; this domain is involved in post-translational import of the protein into the organelle;" ;
     rdfs:label "transit_peptide" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/UniSTS>
+:UniSTS
     a owl:Class ;
     rdfs:label "UniSTS" ;
-    rdfs:subClassOf <http://insdc.org/owl/Database> .
+    rdfs:subClassOf :Database .
 
-<http://insdc.org/owl/Unsure>
+:Unsure
     a owl:Class ;
     rdfs:comment "author is unsure of exact sequence in this region;" ;
     rdfs:label "unsure" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ] .
 
-<http://insdc.org/owl/Variable_Region>
+:Variable_Region
     a owl:Class ;
     rdfs:comment "variable region of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains;  codes for the variable amino terminal portion; can be composed of V_segments, D_segments, N_regions, and J_segments;" ;
     rdfs:label "V_region" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Variable_Segment>
+:Variable_Segment
     a owl:Class ;
     rdfs:comment "variable segment of immunoglobulin light and heavy chains, and T-cell receptor alpha, beta, and gamma chains; codes for most of the variable region (V_region) and the last few amino acids of the leader peptide;" ;
     rdfs:label "V_segment" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/Variation>
+:Variation
     a owl:Class ;
     rdfs:comment "a related strain contains stable mutations from the same gene (e.g., RFLPs, polymorphisms, etc.) which differ from the presented sequence at this location (and possibly others);" ;
     rdfs:label "variation" ;
-    rdfs:subClassOf <http://insdc.org/owl/Feature> ;
+    rdfs:subClassOf :Feature ;
     owl:equivalentClass [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/frequency>
+        owl:onProperty :frequency
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ], [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
-<http://insdc.org/owl/accession>
+:accession
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
+    rdfs:domain :Entry ;
     rdfs:label "accession" .
 
-<http://insdc.org/owl/allele>
+:allele
     a owl:DatatypeProperty ;
     rdfs:comment "name of the allele for the given gene" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "allele" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/altitude>
+:altitude
     a owl:DatatypeProperty ;
     rdfs:comment "geographical altitude of the location from which the sample was collected" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "altitude" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/anticodon>
+:anticodon
     a owl:DatatypeProperty ;
     rdfs:comment "location of the anticodon of tRNA and the amino acid for which it codes" ;
-    rdfs:domain <http://insdc.org/owl/Transfer_RNA> ;
+    rdfs:domain :Transfer_RNA ;
     rdfs:label "anticodon" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/any>
-    a <http://insdc.org/owl/MoleculeScope>, <http://insdc.org/owl/OrganismScope>, owl:NamedIndividual .
+:any
+    a :MoleculeScope, :OrganismScope, owl:NamedIndividual .
 
-<http://insdc.org/owl/artificial_location>
+:artificial_location
     a owl:DatatypeProperty ;
     rdfs:comment "indicates that location of the CDS or mRNA is modified to adjust for the presence of a frameshift or internal stop codon and not because of biological processing between the regions." ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Messenger_RNA>
+        owl:unionOf (:Coding_Sequence
+            :Messenger_RNA
         )
     ] ;
     rdfs:label "artificial_location" ;
@@ -4597,153 +4598,153 @@
             "low-quality sequence region"^^xsd:string
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/bio_material>
+:bio_material
     a owl:DatatypeProperty ;
     rdfs:comment "identifier for the biological material from which the nucleic acid sequenced was obtained, with optional institution code and collection code for the place where it is currently stored." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "bio_material" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/bound_moiety>
+:bound_moiety
     a owl:DatatypeProperty ;
     rdfs:comment "name of the molecule/complex that may bind to the given feature" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
+        owl:unionOf (:Enhancer
+            :Miscellaneous_Binding_Site
+            :Origin_Of_Transfer
+            :Promoter
+            :Protein_Binding_Site
         )
     ] ;
     rdfs:label "bound_moiety" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/cell_line>
+:cell_line
     a owl:DatatypeProperty ;
     rdfs:comment "cell line from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "cell_line" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/cell_type>
+:cell_type
     a owl:DatatypeProperty ;
     rdfs:comment "cell type from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "cell_type" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/chromosome>
+:chromosome
     a owl:DatatypeProperty ;
     rdfs:comment "chromosome (e.g. Chromosome number) from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "chromosome" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> ;
-    owl:propertyDisjointWith <http://insdc.org/owl/plasmid> .
+    rdfs:subPropertyOf :qualifier ;
+    owl:propertyDisjointWith :plasmid .
 
-<http://insdc.org/owl/circular>
-    a <http://insdc.org/owl/Topology>, owl:NamedIndividual .
+:circular
+    a :Topology, owl:NamedIndividual .
 
-<http://insdc.org/owl/citation>
+:citation
     a owl:DatatypeProperty ;
     rdfs:comment "reference to a citation listed in the entry reference field" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Centromere>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Source>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Telomere>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Centromere
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Source
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Telomere
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "citation" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/clone>
+:clone
     a owl:DatatypeProperty ;
     rdfs:comment "clone from which the sequence was obtained" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Source>
+        owl:unionOf (:Miscellaneous_Difference
+            :Source
         )
     ] ;
     rdfs:label "clone" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/clone_lib>
+:clone_lib
     a owl:DatatypeProperty ;
     rdfs:comment "clone library from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "clone_lib" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/codon_start>
+:codon_start
     a owl:DatatypeProperty ;
     rdfs:comment "indicates the offset at which the first complete codon of a coding feature can be found, relative to the first base of that" ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "codon_start" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -4752,163 +4753,163 @@
             3
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/collected_by>
+:collected_by
     a owl:DatatypeProperty ;
     rdfs:comment "name of persons or institute who collected the specimen" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "collected_by" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/collection_date>
+:collection_date
     a owl:DatatypeProperty ;
     rdfs:comment "date that the specimen was collected" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "collection_date" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/comment>
+:comment
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
+    rdfs:domain :Entry ;
     rdfs:label "comment" .
 
-<http://insdc.org/owl/compare>
+:compare
     a owl:DatatypeProperty ;
     rdfs:comment "Reference details of an existing public INSD entry to which a comparison is made" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Miscellaneous_Difference
+            :Unsure
+            :Variation
         )
     ] ;
     rdfs:label "compare" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/contig>
+:contig
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/country>
+:country
     a owl:DatatypeProperty ;
     rdfs:comment "locality of isolation of the sequenced organism indicated in terms of political names for nations, oceans or seas, followed by regions and localities" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "country" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/cultivar>
+:cultivar
     a owl:DatatypeProperty ;
     rdfs:comment "cultivar (cultivated variety) of plant from which sequence was obtained." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "cultivar" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/culture_collection>
+:culture_collection
     a owl:DatatypeProperty ;
     rdfs:comment "institution code and identifier for the culture from which the nucleic acid sequenced was obtained, with optional collection code." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "culture_collection" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/date>
+:date
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/db_xref>
+:db_xref
     a owl:DatatypeProperty ;
     rdfs:comment "database cross-reference: pointer to related information in another database." ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Centromere>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Source>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Telomere>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Centromere
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Source
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Telomere
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "db_xref" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/dblink>
+:dblink
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/definition>
+:definition
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/dev_stage>
+:dev_stage
     a owl:DatatypeProperty ;
     rdfs:comment "if the sequence was obtained from an organism in a specific developmental stage, it is specified with this qualifier" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "dev_stage" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/direction>
+:direction
     a owl:DatatypeProperty ;
     rdfs:comment "direction of DNA replication" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Replication_Origin>
+        owl:unionOf (:Origin_Of_Transfer
+            :Replication_Origin
         )
     ] ;
     rdfs:label "direction" ;
@@ -4919,38 +4920,38 @@
             "right"^^xsd:string
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/division>
+:division
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/double-stranded>
-    a <http://insdc.org/owl/Strand>, owl:NamedIndividual .
+:double-stranded
+    a :Strand, owl:NamedIndividual .
 
-<http://insdc.org/owl/ecotype>
+:ecotype
     a owl:DatatypeProperty ;
     rdfs:comment "a population within a given species displaying genetically based, phenotypic traits that reflect adaptation to a local habitat." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "ecotype" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/environmental_sample>
+:environmental_sample
     a owl:DatatypeProperty ;
     rdfs:comment "identifies sequences derived by direct molecular isolation from a bulk environmental DNA sample (by PCR with or without subsequent cloning of the product, DGGE, or other anonymous methods) with no reliable identification of the source organism. Environmental samples include clinical samples, gut contents, and other sequences from anonymous organisms that may be associated with a particular host. They do not include endosymbionts that can be reliably recovered from a particular host, organisms from a readily identifiable but uncultured field sample (e.g., many cyanobacteria), or phytoplasmas that can be reliably recovered from diseased plants (even though these cannot be grown in axenic culture)." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "environmental_sample" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> ;
-    owl:propertyDisjointWith <http://insdc.org/owl/strain> .
+    rdfs:subPropertyOf :qualifier ;
+    owl:propertyDisjointWith :strain .
 
-<http://insdc.org/owl/estimated_length>
+:estimated_length
     a owl:DatatypeProperty ;
     rdfs:comment "estimated length of the gap in the sequence" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Assembly_Gap>
-            <http://insdc.org/owl/Gap>
+        owl:unionOf (:Assembly_Gap
+            :Gap
         )
     ] ;
     rdfs:label "estimated_length" ;
@@ -4964,18 +4965,18 @@
             ]
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/eukaryotes>
-    a <http://insdc.org/owl/OrganismScope>, owl:NamedIndividual .
+:eukaryotes
+    a :OrganismScope, owl:NamedIndividual .
 
-<http://insdc.org/owl/eukaryotes_and_eukaryotic_viruses>
-    a <http://insdc.org/owl/OrganismScope>, owl:NamedIndividual .
+:eukaryotes_and_eukaryotic_viruses
+    a :OrganismScope, owl:NamedIndividual .
 
-<http://insdc.org/owl/exception>
+:exception
     a owl:DatatypeProperty ;
     rdfs:comment "indicates that the coding region cannot be translated using standard biological rules" ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "exception" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -4985,150 +4986,150 @@
             "reasons given in citation"^^xsd:string
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/experiment>
+:experiment
     a owl:DatatypeProperty ;
     rdfs:comment "a brief description of the nature of the experimental evidence that supports the feature identification or assignment." ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Centromere>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Gap>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Telomere>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Centromere
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Gap
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Telomere
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "experiment" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/feature>
+:feature
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
-    rdfs:range <http://insdc.org/owl/Feature> .
+    rdfs:domain :Entry ;
+    rdfs:range :Feature .
 
-<http://insdc.org/owl/ff_definition>
+:ff_definition
     a owl:DatatypeProperty ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/focus>
+:focus
     a owl:DatatypeProperty ;
     rdfs:comment "identifies the source feature of primary biological interest for records that have multiple source features originating from different organisms and that are not transgenic." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "focus" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/frequency>
+:frequency
     a owl:DatatypeProperty ;
     rdfs:comment "frequency of the occurrence of a feature" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/Source>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Modified_Base
+            :Source
+            :Variation
         )
     ] ;
     rdfs:label "frequency" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/function>
+:function
     a owl:DatatypeProperty ;
     rdfs:comment "function attributed to a sequence" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
+        owl:unionOf (:Coding_Sequence
+            :Exon
+            :Five_Prime_UTR
+            :Intervening_DNA
+            :Intron
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Non_Coding_RNA
+            :Operon
+            :Precursor_RNA
+            :Primary_Transcript
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Ribosomal_RNA
+            :Signal_Peptide
+            :Stem_Loop
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
         )
     ] ;
     rdfs:label "function" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/gap_type>
+:gap_type
     a owl:DatatypeProperty ;
     rdfs:comment "type of gap connecting components in records of a genome assembly, or the type of biological gap in a record that is part of a genome assembly;" ;
-    rdfs:domain <http://insdc.org/owl/Assembly_Gap> ;
+    rdfs:domain :Assembly_Gap ;
     rdfs:label "gap_type" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -5143,309 +5144,309 @@
         )
     ] ;
     rdfs:seeAlso <http://www.ncbi.nlm.nih.gov/projects/genome/assembly/agp/AGP_Specification.shtml> ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/gene>
+:gene
     a owl:DatatypeProperty ;
     rdfs:comment "symbol of the gene corresponding to a sequence region" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "gene" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/gene_synonym>
+:gene_synonym
     a owl:DatatypeProperty ;
     rdfs:comment "synonymous, replaced, obsolete or former gene symbol" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "gene_synonym" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/germline>
+:germline
     a owl:DatatypeProperty ;
     rdfs:comment "the sequence presented in the entry has not undergone somatic rearrangement as part of an adaptive immune response; it is the unrearranged sequence that was inherited from the parental germline" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "germline" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> ;
-    owl:propertyDisjointWith <http://insdc.org/owl/rearranged> .
+    rdfs:subPropertyOf :qualifier ;
+    owl:propertyDisjointWith :rearranged .
 
-<http://insdc.org/owl/haplogroup>
+:haplogroup
     a owl:DatatypeProperty ;
     rdfs:comment "name for a group of similar haplotypes that share some sequence variation. Haplogroups are often used to track migration of population groups." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "haplogroup" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/haplotype>
+:haplotype
     a owl:DatatypeProperty ;
     rdfs:comment "name for a combination of alleles that are linked together on the same physical chromosome. In the absence of recombination, each haplotype is inherited as a unit, and may be used to track gene flow in populations." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "haplotype" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/host>
+:host
     a owl:DatatypeProperty ;
     rdfs:comment "natural (as opposed to laboratory) host to the organism from which sequenced molecule was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "host" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/identified_by>
+:identified_by
     a owl:DatatypeProperty ;
     rdfs:comment "name of the expert who identified the specimen taxonomically" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "identified_by" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/inference>
+:inference
     a owl:DatatypeProperty ;
     rdfs:comment "a structured description of non-experimental evidence that supports the feature identification or assignment." ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Centromere>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Gap>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Telomere>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Centromere
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Gap
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Telomere
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "inference" ;
     rdfs:seeAlso <http://www.insdc.org/inference.html> ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/isMandatoryQualifierOf>
+:isMandatoryQualifierOf
     a owl:ObjectProperty .
 
-<http://insdc.org/owl/isOptionalQualifierOf>
+:isOptionalQualifierOf
     a owl:ObjectProperty .
 
-<http://insdc.org/owl/isolate>
+:isolate
     a owl:DatatypeProperty ;
     rdfs:comment "individual isolate from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "isolate" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/isolation_source>
+:isolation_source
     a owl:DatatypeProperty ;
     rdfs:comment "describes the physical, environmental and/or local geographical source of the biological sample from which the sequence was derived" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "isolation_source" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/keyword>
+:keyword
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
-    rdfs:range <http://insdc.org/owl/Keyword> .
+    rdfs:domain :Entry ;
+    rdfs:range :Keyword .
 
-<http://insdc.org/owl/lab_host>
+:lab_host
     a owl:DatatypeProperty ;
     rdfs:comment "scientific name of the laboratory host used to propagate the source organism from which the sequenced molecule was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "lab_host" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/lat_lon>
+:lat_lon
     a owl:DatatypeProperty ;
     rdfs:comment "geographical coordinates of the location where the specimen was collected" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "lat_lon" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/length>
+:length
     a owl:DatatypeProperty ;
-    rdfs:domain <http://insdc.org/owl/Sequence> .
+    rdfs:domain :Sequence .
 
-<http://insdc.org/owl/lineage>
+:lineage
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/linear>
-    a <http://insdc.org/owl/Topology>, owl:NamedIndividual .
+:linear
+    a :Topology, owl:NamedIndividual .
 
-<http://insdc.org/owl/linkage_evidence>
+:linkage_evidence
     a owl:DatatypeProperty ;
     rdfs:comment "type of evidence establishing linkage across an assembly_gap. Only allowed to be used with assembly_gap features that have a /gap_type value of \"within scaffold\" or \"repeat within scaffold\";" ;
-    rdfs:domain <http://insdc.org/owl/Assembly_Gap> ;
+    rdfs:domain :Assembly_Gap ;
     rdfs:label "linkage_evidence" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -5462,187 +5463,187 @@
         )
     ] ;
     rdfs:seeAlso <http://www.ncbi.nlm.nih.gov/projects/genome/assembly/agp/AGP_Specification.shtml> ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/locus>
+:locus
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/locus_tag>
+:locus_tag
     a owl:DatatypeProperty ;
     rdfs:comment "a submitter-supplied, systematic, stable identifier for a gene and its associated features, used for tracking purposes" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "locus_tag" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/mRNA>
-    a <http://insdc.org/owl/Molecule>, owl:NamedIndividual .
+:mRNA
+    a :Molecule, owl:NamedIndividual .
 
-<http://insdc.org/owl/macronuclear>
+:macronuclear
     a owl:DatatypeProperty ;
     rdfs:comment "if the sequence shown is DNA and from an organism which undergoes chromosomal differentiation between macronuclear and micronuclear stages, this qualifier is used to denote that the sequence is from macronuclear DNA." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "macronuclear" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/map>
+:map
     a owl:DatatypeProperty ;
     rdfs:comment "genomic map position of feature" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Gap>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Source>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Gap
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Source
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "map" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/mating_type>
+:mating_type
     a owl:DatatypeProperty ;
     rdfs:comment "mating type of the organism from which the sequence was obtained; mating type is used for prokaryotes, and for eukaryotes that undergo meiosis without sexually dimorphic gametes" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "mating_type" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/mixed-stranded>
-    a <http://insdc.org/owl/Strand>, owl:NamedIndividual .
+:mixed-stranded
+    a :Strand, owl:NamedIndividual .
 
-<http://insdc.org/owl/mobile_element_type>
+:mobile_element_type
     a owl:DatatypeProperty ;
     rdfs:comment "type and name or identifier of the mobile element which is described by the parent feature" ;
-    rdfs:domain <http://insdc.org/owl/Mobile_Element> ;
+    rdfs:domain :Mobile_Element ;
     rdfs:label "mobile_element_type" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/mod_base>
+:mod_base
     a owl:DatatypeProperty ;
     rdfs:comment "abbreviation for a modified nucleotide base" ;
-    rdfs:domain <http://insdc.org/owl/Modified_Base> ;
+    rdfs:domain :Modified_Base ;
     rdfs:label "mod_base" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/mol_type>
+:mol_type
     a owl:DatatypeProperty ;
     rdfs:comment "in vivo molecule type of sequence" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "mol_type" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -5659,16 +5660,16 @@
             "viral cRNA"^^xsd:string
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/molecule>
+:molecule
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/ncRNA_class>
+:ncRNA_class
     a owl:DatatypeProperty ;
     rdfs:comment "a structured description of the classification of the non-coding RNA described by the ncRNA parent key" ;
-    rdfs:domain <http://insdc.org/owl/Non_Coding_RNA> ;
+    rdfs:domain :Non_Coding_RNA ;
     rdfs:label "ncRNA_class" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -5694,195 +5695,195 @@
         )
     ] ;
     rdfs:seeAlso <http://www.insdc.org/rna_vocab.html> ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/note>
+:note
     a owl:DatatypeProperty ;
     rdfs:comment "any comment or additional information" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Centromere>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Gap>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Source>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Telomere>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Centromere
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Gap
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Source
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Telomere
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "note" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/number>
+:number
     a owl:DatatypeProperty ;
     rdfs:comment "a number to indicate the order of genetic elements (e.g., exons or introns) in the 5' to 3' direction" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Miscellaneous_Feature>
+        owl:unionOf (:Coding_Sequence
+            :Exon
+            :Intervening_DNA
+            :Intron
+            :Mature_Peptide
+            :Miscellaneous_Feature
         )
     ] ;
     rdfs:label "number" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/old_locus_tag>
+:old_locus_tag
     a owl:DatatypeProperty ;
     rdfs:comment "feature tag assigned for tracking purposes" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/CAAT_Signal>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Displacement_Loop>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/GC_Signal>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Binding_Site>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Modified_Base>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/PolyA_Signal>
-            <http://insdc.org/owl/PolyA_Site>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/TATA_Signal>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :CAAT_Signal
+            :Coding_Sequence
+            :Constant_Region
+            :Displacement_Loop
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :GC_Signal
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Binding_Site
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :Modified_Base
+            :N_Region
+            :Non_Coding_RNA
+            :Origin_Of_Transfer
+            :PolyA_Signal
+            :PolyA_Site
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :TATA_Signal
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Unsure
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "old_locus_tag" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/operon>
+:operon
     a owl:DatatypeProperty ;
     rdfs:comment "name of the group of contiguous genes transcribed into a single transcript to which that feature belongs." ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Gene>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Transfer_RNA>
+        owl:unionOf (:Attenuator
+            :Coding_Sequence
+            :Gene
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_RNA
+            :Miscellaneous_Signal
+            :Non_Coding_RNA
+            :Operon
+            :Precursor_RNA
+            :Primary_Transcript
+            :Promoter
+            :Protein_Binding_Site
+            :Ribosomal_RNA
+            :Stem_Loop
+            :Terminator
+            :Transfer_RNA
         )
     ] ;
     rdfs:label "operon" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/organelle>
+:organelle
     a owl:DatatypeProperty ;
     rdfs:comment "type of membrane-bound intracellular structure from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "organelle" ;
     rdfs:range [
         a rdfs:Datatype ;
@@ -5900,172 +5901,172 @@
             "plastid:proplastid"^^xsd:string
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/organism>
+:organism
     a owl:DatatypeProperty ;
     rdfs:comment "scientific name of the organism that provided the sequenced genetic material." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "organism" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/partial>
+:partial
     a owl:DatatypeProperty ;
     rdfs:comment "differentiates between complete regions and partial ones", "not to be used for new entries from 15-DEC-2001; use '<' and '>' signs in the location descriptors to indicate that the sequence is partial." ;
     rdfs:label "partial" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/phenotype>
+:phenotype
     a owl:DatatypeProperty ;
     rdfs:comment "phenotype conferred by the feature, where phenotype is defined as a physical, biochemical or behavioural characteristic or set of characteristics" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Attenuator>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Attenuator
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_Signal
+            :Operon
+            :Promoter
+            :Variation
         )
     ] ;
     rdfs:label "phenotype" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/plasmid>
+:plasmid
     a owl:DatatypeProperty ;
     rdfs:comment "name of naturally occurring plasmid from which the sequence was obtained, where plasmid is defined as an independently replicating genetic unit that cannot be described by /chromosome or /segment" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "plasmid" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> ;
-    owl:propertyDisjointWith <http://insdc.org/owl/segment> .
+    rdfs:subPropertyOf :qualifier ;
+    owl:propertyDisjointWith :segment .
 
-<http://insdc.org/owl/pop_variant>
+:pop_variant
     a owl:DatatypeProperty ;
     rdfs:comment "name of subpopulation or phenotype of the sample from which the sequence was derived" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "pop_variant" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/product>
+:product
     a owl:DatatypeProperty ;
     rdfs:comment "name of the product associated with the feature, e.g. the mRNA of an mRNA feature, the polypeptide of a CDS, the mature peptide of a mat_peptide, etc." ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Coding_Sequence
+            :Constant_Region
+            :Diversity_Segment
+            :Exon
+            :Joining_Segment
+            :Mature_Peptide
+            :Messenger_RNA
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :N_Region
+            :Non_Coding_RNA
+            :Precursor_RNA
+            :Ribosomal_RNA
+            :Signal_Peptide
+            :Switch_Region
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "product" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/project>
+:project
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> .
+    rdfs:domain :Entry .
 
-<http://insdc.org/owl/prokaryotes>
-    a <http://insdc.org/owl/OrganismScope>, owl:NamedIndividual .
+:prokaryotes
+    a :OrganismScope, owl:NamedIndividual .
 
-<http://insdc.org/owl/protein_id>
+:protein_id
     a owl:DatatypeProperty ;
     rdfs:comment "protein identifier, issued by International collaborators. this qualifier consists of a stable ID portion (3+5 format with 3 position letters and 5 numbers) plus a version number after the decimal point." ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "protein_id" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/proviral>
+:proviral
     a owl:DatatypeProperty ;
     rdfs:comment "this qualifier is used to flag sequence obtained from a virus or phage that is integrated into the genome of another organism" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "proviral" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/pseudo>
+:pseudo
     a owl:DatatypeProperty ;
     rdfs:comment "indicates that this feature is a non-functional version of the element named by the feature key" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
+        owl:unionOf (:Coding_Sequence
+            :Constant_Region
+            :Diversity_Segment
+            :Exon
+            :Intron
+            :Joining_Segment
+            :Mature_Peptide
+            :Messenger_RNA
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Promoter
+            :Ribosomal_RNA
+            :Signal_Peptide
+            :Switch_Region
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Variable_Region
+            :Variable_Segment
         )
     ] ;
     rdfs:label "pseudo" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/pseudogene>
+:pseudogene
     a owl:DatatypeProperty ;
     rdfs:comment "indicates that this feature is a pseudogene of the element named by the feature key" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
+        owl:unionOf (:Coding_Sequence
+            :Constant_Region
+            :Diversity_Segment
+            :Exon
+            :Intron
+            :Joining_Segment
+            :Mature_Peptide
+            :Messenger_RNA
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Promoter
+            :Ribosomal_RNA
+            :Signal_Peptide
+            :Switch_Region
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Variable_Region
+            :Variable_Segment
         )
     ] ;
     rdfs:label "pseudogene" ;
@@ -6079,71 +6080,71 @@
         )
     ] ;
     rdfs:seeAlso <http://www.insdc.org/documents/pseudogene-qualifier-vocabulary> ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/qualifier>
+:qualifier
     a owl:DatatypeProperty ;
-    rdfs:domain <http://insdc.org/owl/Feature> .
+    rdfs:domain :Feature .
 
-<http://insdc.org/owl/rRNA>
-    a <http://insdc.org/owl/Molecule>, owl:NamedIndividual .
+:rRNA
+    a :Molecule, owl:NamedIndividual .
 
-<http://insdc.org/owl/rearranged>
+:rearranged
     a owl:DatatypeProperty ;
     rdfs:comment "the sequence presented in the entry has undergone somatic rearrangement as part of an adaptive immune response; it is not the unrearranged sequence that was inherited from the parental germline" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "rearranged" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/reference>
+:reference
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
-    rdfs:range <http://insdc.org/owl/Reference> .
+    rdfs:domain :Entry ;
+    rdfs:range :Reference .
 
-<http://insdc.org/owl/replace>
+:replace
     a owl:DatatypeProperty ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Unsure>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Miscellaneous_Difference
+            :Unsure
+            :Variation
         )
     ] ;
     rdfs:label "indicates that the sequence identified a feature's intervals is replaced by the sequence shown in \"text\"; if no sequence is contained within the qualifier, this indicates a deletion.", "replace" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/ribosomal_slippage>
+:ribosomal_slippage
     a owl:DatatypeProperty ;
     rdfs:comment "during protein translation, certain sequences can program ribosomes to change to an alternative reading frame by a mechanism known as ribosomal slippage" ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "ribosomal_slippage" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/rpt_family>
+:rpt_family
     a owl:DatatypeProperty ;
     rdfs:comment "type of repeated sequence; \"Alu\" or \"Kpn\", for example" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Repeat_Region>
+        owl:unionOf (:Mobile_Element
+            :Origin_Of_Transfer
+            :Repeat_Region
         )
     ] ;
     rdfs:label "rpt_family" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/rpt_type>
+:rpt_type
     a owl:DatatypeProperty ;
     rdfs:comment "organization of repeated sequence" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Telomere>
+        owl:unionOf (:Origin_Of_Transfer
+            :Repeat_Region
+            :Telomere
         )
     ] ;
     rdfs:label "rpt_type" ;
@@ -6158,281 +6159,281 @@
             "terminal"^^xsd:string
         )
     ] ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/rpt_unit_range>
+:rpt_unit_range
     a owl:DatatypeProperty ;
     rdfs:comment "identity of a repeat range" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Telomere>
+        owl:unionOf (:Origin_Of_Transfer
+            :Repeat_Region
+            :Telomere
         )
     ] ;
     rdfs:label "rpt_unit_range" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/rpt_unit_seq>
+:rpt_unit_seq
     a owl:DatatypeProperty ;
     rdfs:comment "identity of a repeat sequence" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Telomere>
+        owl:unionOf (:Origin_Of_Transfer
+            :Repeat_Region
+            :Telomere
         )
     ] ;
     rdfs:label "rpt_unit_seq" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/satellite>
+:satellite
     a owl:DatatypeProperty ;
     rdfs:comment "identifier for a satellite DNA marker, compose of many tandem repeats (identical or related) of a short basic repeated unit;" ;
-    rdfs:domain <http://insdc.org/owl/Repeat_Region> ;
+    rdfs:domain :Repeat_Region ;
     rdfs:label "satellite" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/segment>
+:segment
     a owl:DatatypeProperty ;
     rdfs:comment "name of viral or phage segment sequenced" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "segment" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/sequence>
+:sequence
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
+    rdfs:domain :Entry ;
     rdfs:label "sequence" ;
-    rdfs:range <http://insdc.org/owl/Sequence> .
+    rdfs:range :Sequence .
 
-<http://insdc.org/owl/serotype>
+:serotype
     a owl:DatatypeProperty ;
     rdfs:comment "serological variety of a species characterized by its antigenic properties" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "serotype" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/serovar>
+:serovar
     a owl:DatatypeProperty ;
     rdfs:comment "serological variety of a species (usually a prokaryote) characterized by its antigenic properties" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "serovar" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/sex>
+:sex
     a owl:DatatypeProperty ;
     rdfs:comment "sex of the organism from which the sequence was obtained; sex is used for eukaryotic organisms that undergo meiosis and have sexually dimorphic gametes" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "sex" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/single-stranded>
-    a <http://insdc.org/owl/Strand>, owl:NamedIndividual .
+:single-stranded
+    a :Strand, owl:NamedIndividual .
 
-<http://insdc.org/owl/specimen_voucher>
+:specimen_voucher
     a owl:DatatypeProperty ;
     rdfs:comment "identifier for the specimen from which the nucleic acid sequenced was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "specimen_voucher" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/standard_name>
+:standard_name
     a owl:DatatypeProperty ;
     rdfs:comment "accepted standard name for this feature" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Centromere>
-            <http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Constant_Region>
-            <http://insdc.org/owl/Diversity_Segment>
-            <http://insdc.org/owl/Enhancer>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/Intervening_DNA>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Joining_Segment>
-            <http://insdc.org/owl/Long_Terminal_Repeat>
-            <http://insdc.org/owl/Mature_Peptide>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Minus_10_Signal>
-            <http://insdc.org/owl/Minus_35_Signal>
-            <http://insdc.org/owl/Miscellaneous_Difference>
-            <http://insdc.org/owl/Miscellaneous_Feature>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Miscellaneous_Recombination_Site>
-            <http://insdc.org/owl/Miscellaneous_Signal>
-            <http://insdc.org/owl/Miscellaneous_Structure>
-            <http://insdc.org/owl/Mobile_Element>
-            <http://insdc.org/owl/N_Region>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Operon>
-            <http://insdc.org/owl/Origin_Of_Transfer>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Primary_Transcript>
-            <http://insdc.org/owl/Primer_Binding_Site>
-            <http://insdc.org/owl/Promoter>
-            <http://insdc.org/owl/Protein_Binding_Site>
-            <http://insdc.org/owl/Repeat_Region>
-            <http://insdc.org/owl/Replication_Origin>
-            <http://insdc.org/owl/Ribosomal_RNA>
-            <http://insdc.org/owl/Ribosome_Binding_Site>
-            <http://insdc.org/owl/Sequence_Tagged_Site>
-            <http://insdc.org/owl/Signal_Peptide>
-            <http://insdc.org/owl/Stem_Loop>
-            <http://insdc.org/owl/Switch_Region>
-            <http://insdc.org/owl/Telomere>
-            <http://insdc.org/owl/Terminator>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_Messenger_RNA>
-            <http://insdc.org/owl/Transfer_RNA>
-            <http://insdc.org/owl/Transit_Peptide>
-            <http://insdc.org/owl/Variable_Region>
-            <http://insdc.org/owl/Variable_Segment>
-            <http://insdc.org/owl/Variation>
+        owl:unionOf (:Centromere
+            :Coding_Sequence
+            :Constant_Region
+            :Diversity_Segment
+            :Enhancer
+            :Exon
+            :Five_Prime_UTR
+            :Intervening_DNA
+            :Intron
+            :Joining_Segment
+            :Long_Terminal_Repeat
+            :Mature_Peptide
+            :Messenger_RNA
+            :Minus_10_Signal
+            :Minus_35_Signal
+            :Miscellaneous_Difference
+            :Miscellaneous_Feature
+            :Miscellaneous_RNA
+            :Miscellaneous_Recombination_Site
+            :Miscellaneous_Signal
+            :Miscellaneous_Structure
+            :Mobile_Element
+            :N_Region
+            :Non_Coding_RNA
+            :Operon
+            :Origin_Of_Transfer
+            :Precursor_RNA
+            :Primary_Transcript
+            :Primer_Binding_Site
+            :Promoter
+            :Protein_Binding_Site
+            :Repeat_Region
+            :Replication_Origin
+            :Ribosomal_RNA
+            :Ribosome_Binding_Site
+            :Sequence_Tagged_Site
+            :Signal_Peptide
+            :Stem_Loop
+            :Switch_Region
+            :Telomere
+            :Terminator
+            :Three_Prime_UTR
+            :Transfer_Messenger_RNA
+            :Transfer_RNA
+            :Transit_Peptide
+            :Variable_Region
+            :Variable_Segment
+            :Variation
         )
     ] ;
     rdfs:label "standard_name" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/strain>
+:strain
     a owl:DatatypeProperty ;
     rdfs:comment "strain from which sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "strain" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/stranded>
+:stranded
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
+    rdfs:domain :Entry ;
     rdfs:label "stranded" .
 
-<http://insdc.org/owl/sub_clone>
+:sub_clone
     a owl:DatatypeProperty ;
     rdfs:comment "sub-clone from which sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "sub_clone" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/sub_species>
+:sub_species
     a owl:DatatypeProperty ;
     rdfs:comment "name of sub-species of organism from which sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "sub_species" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/sub_strain>
+:sub_strain
     a owl:DatatypeProperty ;
     rdfs:comment "name or identifier of a genetically or otherwise modified strain from which sequence was obtained, derived from a parental strain (which should be annotated in the /strain qualifier).sub_strain from which sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "sub_strain" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/tRNA>
-    a <http://insdc.org/owl/Molecule>, owl:NamedIndividual .
+:tRNA
+    a :Molecule, owl:NamedIndividual .
 
-<http://insdc.org/owl/tag_peptide>
+:tag_peptide
     a owl:DatatypeProperty ;
     rdfs:comment "base location encoding the polypeptide for proteolysis tag of tmRNA and its termination codon;" ;
-    rdfs:domain <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    rdfs:domain :Transfer_Messenger_RNA ;
     rdfs:label "tag_peptide" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/tissue_lib>
+:tissue_lib
     a owl:DatatypeProperty ;
     rdfs:comment "tissue library from which sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "tissue_lib" ;
     rdfs:range rdfs:Literal ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/tissue_type>
+:tissue_type
     a owl:DatatypeProperty ;
     rdfs:comment "tissue type from which the sequence was obtained" ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "tissue_type" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/topology>
+:topology
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Sequence> .
+    rdfs:domain :Sequence .
 
-<http://insdc.org/owl/trans_splicing>
+:trans_splicing
     a owl:DatatypeProperty ;
     rdfs:comment "indicates that exons from two RNA molecules are ligated in intermolecular reaction to form mature RNA" ;
     rdfs:domain [
         a owl:Class ;
-        owl:unionOf (<http://insdc.org/owl/Coding_Sequence>
-            <http://insdc.org/owl/Exon>
-            <http://insdc.org/owl/Five_Prime_UTR>
-            <http://insdc.org/owl/Intron>
-            <http://insdc.org/owl/Messenger_RNA>
-            <http://insdc.org/owl/Miscellaneous_RNA>
-            <http://insdc.org/owl/Non_Coding_RNA>
-            <http://insdc.org/owl/Precursor_RNA>
-            <http://insdc.org/owl/Three_Prime_UTR>
-            <http://insdc.org/owl/Transfer_RNA>
+        owl:unionOf (:Coding_Sequence
+            :Exon
+            :Five_Prime_UTR
+            :Intron
+            :Messenger_RNA
+            :Miscellaneous_RNA
+            :Non_Coding_RNA
+            :Precursor_RNA
+            :Three_Prime_UTR
+            :Transfer_RNA
         )
     ] ;
     rdfs:label "trans_splicing" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/transgenic>
+:transgenic
     a owl:DatatypeProperty ;
     rdfs:comment "identifies the source feature of the organism which was the recipient of transgenic DNA." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "transgenic" ;
     rdfs:range xsd:boolean ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/transl_except>
+:transl_except
     a owl:DatatypeProperty ;
     rdfs:comment "translational exception: single codon the translation of which does not conform to genetic code defined by /organism or /transl_table." ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "transl_except" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/transl_table>
+:transl_table
     a owl:DatatypeProperty ;
     rdfs:comment "definition of genetic code table used if other than universal genetic code table. Tables used are described in appendix IV." ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "transl_table" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/translation>
+:translation
     a owl:DatatypeProperty ;
     rdfs:comment "automatically generated one-letter abbreviated amino acid sequence derived from either the universal genetic code or the table as specified in /transl_table and as determined by an exception in the /transl_except qualifier" ;
-    rdfs:domain <http://insdc.org/owl/Coding_Sequence> ;
+    rdfs:domain :Coding_Sequence ;
     rdfs:label "translation" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/uRNA>
-    a <http://insdc.org/owl/Molecule>, owl:NamedIndividual .
+:uRNA
+    a :Molecule, owl:NamedIndividual .
 
-<http://insdc.org/owl/unknown>
-    a <http://insdc.org/owl/Strand>, owl:NamedIndividual .
+:unknown
+    a :Strand, owl:NamedIndividual .
 
-<http://insdc.org/owl/variety>
+:variety
     a owl:DatatypeProperty ;
     rdfs:comment "variety (= varietas, a formal Linnaean rank) of organism from which sequence was derived." ;
-    rdfs:domain <http://insdc.org/owl/Source> ;
+    rdfs:domain :Source ;
     rdfs:label "variety" ;
-    rdfs:subPropertyOf <http://insdc.org/owl/qualifier> .
+    rdfs:subPropertyOf :qualifier .
 
-<http://insdc.org/owl/version>
+:version
     a owl:ObjectProperty ;
-    rdfs:domain <http://insdc.org/owl/Entry> ;
+    rdfs:domain :Entry ;
     rdfs:label "version" .
 
 xsd:date
@@ -6440,10254 +6441,10255 @@ xsd:date
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Assembly_Gap> ;
+    owl:annotatedSource :Assembly_Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/estimated_length>
+        owl:onProperty :estimated_length
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Assembly_Gap> ;
+    owl:annotatedSource :Assembly_Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gap_type>
+        owl:onProperty :gap_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Assembly_Gap> ;
+    owl:annotatedSource :Assembly_Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/linkage_evidence>
+        owl:onProperty :linkage_evidence
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Attenuator> ;
+    owl:annotatedSource :Attenuator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Constant_Region> ;
+    owl:annotatedSource :Constant_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/CAAT_Signal> ;
+    owl:annotatedSource :CAAT_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/artificial_location>
+        owl:onProperty :artificial_location
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/codon_start>
+        owl:onProperty :codon_start
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/EC_number>
+        owl:onProperty :EC_number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/exception>
+        owl:onProperty :exception
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/protein_id>
+        owl:onProperty :protein_id
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/ribosomal_slippage>
+        owl:onProperty :ribosomal_slippage
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/translation>
+        owl:onProperty :translation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/transl_except>
+        owl:onProperty :transl_except
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/transl_table>
+        owl:onProperty :transl_table
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Coding_Sequence> ;
+    owl:annotatedSource :Coding_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Centromere> ;
+    owl:annotatedSource :Centromere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Centromere> ;
+    owl:annotatedSource :Centromere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Centromere> ;
+    owl:annotatedSource :Centromere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Centromere> ;
+    owl:annotatedSource :Centromere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Centromere> ;
+    owl:annotatedSource :Centromere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Centromere> ;
+    owl:annotatedSource :Centromere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Displacement_Loop> ;
+    owl:annotatedSource :Displacement_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Diversity_Segment> ;
+    owl:annotatedSource :Diversity_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Enhancer> ;
+    owl:annotatedSource :Enhancer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/EC_number>
+        owl:onProperty :EC_number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Exon> ;
+    owl:annotatedSource :Exon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gap> ;
+    owl:annotatedSource :Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/estimated_length>
+        owl:onProperty :estimated_length
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gap> ;
+    owl:annotatedSource :Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gap> ;
+    owl:annotatedSource :Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gap> ;
+    owl:annotatedSource :Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gap> ;
+    owl:annotatedSource :Gap ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/GC_Signal> ;
+    owl:annotatedSource :GC_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Gene> ;
+    owl:annotatedSource :Gene ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intervening_DNA> ;
+    owl:annotatedSource :Intervening_DNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Intron> ;
+    owl:annotatedSource :Intron ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Joining_Segment> ;
+    owl:annotatedSource :Joining_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Long_Terminal_Repeat> ;
+    owl:annotatedSource :Long_Terminal_Repeat ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/EC_number>
+        owl:onProperty :EC_number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mature_Peptide> ;
+    owl:annotatedSource :Mature_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :bound_moiety
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Binding_Site> ;
+    owl:annotatedSource :Miscellaneous_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/clone>
+        owl:onProperty :clone
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Difference> ;
+    owl:annotatedSource :Miscellaneous_Difference ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/number>
+        owl:onProperty :number
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Feature> ;
+    owl:annotatedSource :Miscellaneous_Feature ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Recombination_Site> ;
+    owl:annotatedSource :Miscellaneous_Recombination_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_RNA> ;
+    owl:annotatedSource :Miscellaneous_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Signal> ;
+    owl:annotatedSource :Miscellaneous_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Miscellaneous_Structure> ;
+    owl:annotatedSource :Miscellaneous_Structure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mobile_element_type>
+        owl:onProperty :mobile_element_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_family>
+        owl:onProperty :rpt_family
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :rpt_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Mobile_Element> ;
+    owl:annotatedSource :Mobile_Element ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mod_base>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/frequency>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Modified_Base> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/artificial_location>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Messenger_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/ncRNA_class>
+        owl:onProperty :mod_base
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :frequency
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Modified_Base ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :artificial_location
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Non_Coding_RNA> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
+    owl:annotatedSource :Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/N_Region> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
+    owl:annotatedSource :Non_Coding_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :ncRNA_class
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :function
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :operon
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :product
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudo
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudogene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Non_Coding_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :trans_splicing
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :product
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudo
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudogene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :N_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Old_Sequence> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :compare
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
+    owl:annotatedSource :Old_Sequence ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :replace
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Operon> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/direction>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_family>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_range>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_seq>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Origin_Of_Transfer> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Signal> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/PolyA_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Precursor_RNA> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primary_Transcript> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Primer_Binding_Site> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/PCR_conditions>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Promoter> ;
-    owl:annotatedTarget [
-        a owl:Restriction ;
-        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
-    ] .
-
-[]
-    a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
-    owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bound_moiety>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Operon ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Protein_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :bound_moiety
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :direction
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosome_Binding_Site> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :rpt_family
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :rpt_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :rpt_unit_range
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :rpt_unit_seq
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :Origin_Of_Transfer ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_family>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_range>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_seq>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/satellite>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Repeat_Region> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :PolyA_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Ribosomal_RNA> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Precursor_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Switch_Region> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primary_Transcript ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Signal_Peptide> ;
+    owl:annotatedSource :Primer_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Primer_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Primer_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Primer_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :PCR_conditions
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :bound_moiety
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :function
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :operon
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :phenotype
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudo
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudogene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Promoter ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/organism>
+        owl:onProperty :bound_moiety
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :function
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :operon
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Protein_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosome_Binding_Site ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :function
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :rpt_family
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :rpt_type
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :rpt_unit_range
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :rpt_unit_seq
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :satellite
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Repeat_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :function
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :operon
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :product
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudo
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudogene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Ribosomal_RNA ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :product
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudo
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudogene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Switch_Region ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :allele
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :citation
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :db_xref
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :experiment
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :function
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :gene_synonym
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :inference
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :map
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :note
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :old_locus_tag
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :product
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudo
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :pseudogene
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Signal_Peptide ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
+        owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :standard_name
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:cardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mol_type>
+        owl:onProperty :organism
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
+        owl:cardinality "1"^^xsd:nonNegativeInteger ;
+        owl:onProperty :mol_type
+    ] .
+
+[]
+    a owl:Axiom ;
+    rdfs:isDefinedBy :OptionalQualifier ;
+    owl:annotatedProperty owl:equivalentClass ;
+    owl:annotatedSource :Source ;
+    owl:annotatedTarget [
+        a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/altitude>
+        owl:onProperty :altitude
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/bio_material>
+        owl:onProperty :bio_material
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/cell_line>
+        owl:onProperty :cell_line
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/cell_type>
+        owl:onProperty :cell_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/chromosome>
+        owl:onProperty :chromosome
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/clone>
+        owl:onProperty :clone
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/clone_lib>
+        owl:onProperty :clone_lib
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/collected_by>
+        owl:onProperty :collected_by
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/collection_date>
+        owl:onProperty :collection_date
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/country>
+        owl:onProperty :country
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/cultivar>
+        owl:onProperty :cultivar
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/culture_collection>
+        owl:onProperty :culture_collection
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/dev_stage>
+        owl:onProperty :dev_stage
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/ecotype>
+        owl:onProperty :ecotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/environmental_sample>
+        owl:onProperty :environmental_sample
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/focus>
+        owl:onProperty :focus
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/germline>
+        owl:onProperty :germline
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/haplogroup>
+        owl:onProperty :haplogroup
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/haplotype>
+        owl:onProperty :haplotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/host>
+        owl:onProperty :host
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/identified_by>
+        owl:onProperty :identified_by
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/isolate>
+        owl:onProperty :isolate
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/isolation_source>
+        owl:onProperty :isolation_source
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/lab_host>
+        owl:onProperty :lab_host
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/lat_lon>
+        owl:onProperty :lat_lon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/macronuclear>
+        owl:onProperty :macronuclear
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/mating_type>
+        owl:onProperty :mating_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/organelle>
+        owl:onProperty :organelle
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/PCR_primers>
+        owl:onProperty :PCR_primers
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/plasmid>
+        owl:onProperty :plasmid
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pop_variant>
+        owl:onProperty :pop_variant
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/proviral>
+        owl:onProperty :proviral
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rearranged>
+        owl:onProperty :rearranged
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/segment>
+        owl:onProperty :segment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/serotype>
+        owl:onProperty :serotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/serovar>
+        owl:onProperty :serovar
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sex>
+        owl:onProperty :sex
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/specimen_voucher>
+        owl:onProperty :specimen_voucher
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/strain>
+        owl:onProperty :strain
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sub_clone>
+        owl:onProperty :sub_clone
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sub_species>
+        owl:onProperty :sub_species
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/sub_strain>
+        owl:onProperty :sub_strain
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/tissue_lib>
+        owl:onProperty :tissue_lib
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/tissue_type>
+        owl:onProperty :tissue_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/transgenic>
+        owl:onProperty :transgenic
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/type_material>
+        owl:onProperty :type_material
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Source> ;
+    owl:annotatedSource :Source ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/variety>
+        owl:onProperty :variety
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Stem_Loop> ;
+    owl:annotatedSource :Stem_Loop ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Sequence_Tagged_Site> ;
+    owl:annotatedSource :Sequence_Tagged_Site ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/TATA_Signal> ;
+    owl:annotatedSource :TATA_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_type>
+        owl:onProperty :rpt_type
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_range>
+        owl:onProperty :rpt_unit_range
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/rpt_unit_seq>
+        owl:onProperty :rpt_unit_seq
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Telomere> ;
+    owl:annotatedSource :Telomere ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Terminator> ;
+    owl:annotatedSource :Terminator ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_Messenger_RNA> ;
+    owl:annotatedSource :Transfer_Messenger_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/tag_peptide>
+        owl:onProperty :tag_peptide
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transit_Peptide> ;
+    owl:annotatedSource :Transit_Peptide ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/anticodon>
+        owl:onProperty :anticodon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Transfer_RNA> ;
+    owl:annotatedSource :Transfer_RNA ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Unsure> ;
+    owl:annotatedSource :Unsure ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Region> ;
+    owl:annotatedSource :Variable_Region ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudo>
+        owl:onProperty :pseudo
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/pseudogene>
+        owl:onProperty :pseudogene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variable_Segment> ;
+    owl:annotatedSource :Variable_Segment ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/compare>
+        owl:onProperty :compare
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/frequency>
+        owl:onProperty :frequency
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/phenotype>
+        owl:onProperty :phenotype
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/product>
+        owl:onProperty :product
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/replace>
+        owl:onProperty :replace
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Variation> ;
+    owl:annotatedSource :Variation ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Three_Prime_UTR> ;
+    owl:annotatedSource :Three_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/function>
+        owl:onProperty :function
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Five_Prime_UTR> ;
+    owl:annotatedSource :Five_Prime_UTR ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/trans_splicing>
+        owl:onProperty :trans_splicing
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_10_Signal> ;
+    owl:annotatedSource :Minus_10_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/allele>
+        owl:onProperty :allele
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/citation>
+        owl:onProperty :citation
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/db_xref>
+        owl:onProperty :db_xref
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/experiment>
+        owl:onProperty :experiment
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene>
+        owl:onProperty :gene
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/gene_synonym>
+        owl:onProperty :gene_synonym
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/inference>
+        owl:onProperty :inference
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/locus_tag>
+        owl:onProperty :locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/map>
+        owl:onProperty :map
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/note>
+        owl:onProperty :note
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/old_locus_tag>
+        owl:onProperty :old_locus_tag
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/operon>
+        owl:onProperty :operon
     ] .
 
 []
     a owl:Axiom ;
-    rdfs:isDefinedBy <http://insdc.org/owl/OptionalQualifier> ;
+    rdfs:isDefinedBy :OptionalQualifier ;
     owl:annotatedProperty owl:equivalentClass ;
-    owl:annotatedSource <http://insdc.org/owl/Minus_35_Signal> ;
+    owl:annotatedSource :Minus_35_Signal ;
     owl:annotatedTarget [
         a owl:Restriction ;
         owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-        owl:onProperty <http://insdc.org/owl/standard_name>
+        owl:onProperty :standard_name
     ] .
 
 []
     a owl:AllDifferent ;
-    owl:distinctMembers (<http://insdc.org/owl/circular>
-        <http://insdc.org/owl/linear>
+    owl:distinctMembers (:circular
+        :linear
     ) .
 
 []
     a owl:AllDifferent ;
-    owl:distinctMembers (<http://insdc.org/owl/DNA>
-        <http://insdc.org/owl/NA>
-        <http://insdc.org/owl/RNA>
-        <http://insdc.org/owl/mRNA>
-        <http://insdc.org/owl/rRNA>
-        <http://insdc.org/owl/tRNA>
-        <http://insdc.org/owl/uRNA>
+    owl:distinctMembers (:DNA
+        :NA
+        :RNA
+        :mRNA
+        :rRNA
+        :tRNA
+        :uRNA
     ) .
 
 []
     a owl:AllDifferent ;
-    owl:distinctMembers (<http://insdc.org/owl/double-stranded>
-        <http://insdc.org/owl/mixed-stranded>
-        <http://insdc.org/owl/single-stranded>
+    owl:distinctMembers (:double-stranded
+        :mixed-stranded
+        :single-stranded
     ) .
+


### PR DESCRIPTION
Because http://insdc.org/owl/ have not authorized yet, we would replace it to DDBJ URIs for release.
If authorized, we can replace the @base URI and add equivalentClass/sameAs links to DDBJ/GenBank/ENA URIs.
